### PR TITLE
Added stylus support

### DIFF
--- a/.npm/plugin/mss/npm-shrinkwrap.json
+++ b/.npm/plugin/mss/npm-shrinkwrap.json
@@ -2611,6 +2611,83 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
       "from": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz"
+    },
+    "stylus": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.2.tgz",
+      "from": "stylus@0.54.2",
+      "dependencies": {
+        "css-parse": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
+          "from": "css-parse@>=1.7.0 <1.8.0"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "from": "debug@*",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "from": "ms@0.7.1"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "from": "glob@>=3.2.0 <3.3.0",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0"
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "from": "minimatch@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "sigmund": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8"
+            }
+          }
+        },
+        "sax": {
+          "version": "0.5.8",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+          "from": "sax@>=0.5.0 <0.6.0"
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "from": "source-map@>=0.1.0 <0.2.0",
+          "dependencies": {
+            "amdefine": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+              "from": "amdefine@>=0.0.4"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ This can be configured by setting the `extensions` property in the cssModules co
 To enable Sass compilation, set the aforementioned `extensions` property to `['scss', 'sass']`.
 If you are using a different file extension, set it in the `extensions` property, and also set the `enableSassCompilation` property, which defaults to `['scss', 'sass']`.
 
+## New: Stylus support!
+
+To enable Stylus compilation, set the aforementioned `extensions` property to `['m.styl']`.
+If you are using a different file extension, set it in the `extensions` property, and also set the `enableStylusCompilation` property, which defaults to `['m.styl']`.
+
 
 ## Usage
 

--- a/css-modules-build-plugin.js
+++ b/css-modules-build-plugin.js
@@ -3,6 +3,7 @@ import Future from 'fibers/future';
 import LRU from 'lru-cache';
 import recursive from 'recursive-readdir';
 import ScssProcessor from './scss-processor';
+import StylusProcessor from './stylus-processor';
 import CssModulesProcessor from './css-modules-processor';
 import IncludedFile from './included-file';
 import pluginOptions from './options';
@@ -47,6 +48,8 @@ export default class CssModulesBuildPlugin extends CachingCompiler {
 		const uncachedFiles = processCachedFiles.call(this, files);
 		if (pluginOptions.enableSassCompilation)
 			compileScssFiles.call(this, uncachedFiles);
+		if (pluginOptions.enableStylusCompilation)
+			compileStylusFiles.call(this, uncachedFiles);
 		compileCssModules.call(this, uncachedFiles);
 
 		profile(start, 'compilation complete in');
@@ -148,6 +151,60 @@ export default class CssModulesBuildPlugin extends CachingCompiler {
 				} catch (err) {
 					file.error({
 						message: `CSS modules SCSS compiler error: ${JSON.stringify(err, Object.getOwnPropertyNames(err))}\n`,
+						sourcePath: file.getDisplayPath()
+					});
+					return null;
+				}
+
+				file.getContentsAsString = function getContentsAsString() {
+					return result.source;
+				};
+			}
+		}
+
+		function compileStylusFiles(files) {
+			const processor = new StylusProcessor('./', allFiles);
+			const isStylusRoot = (file)=>isStylus(file) && isRoot(file);
+			const compileFile = compileStylusFile.bind(this);
+			files.filter(isStylusRoot).forEach(compileFile);
+
+			function isStylus(file) {
+				if (pluginOptions.enableStylusCompilation === true)
+					return true;
+
+				return _.find(pluginOptions.enableStylusCompilation, (ext) => (
+					file.getPathInPackage().endsWith(ext)
+				))
+			}
+
+			function isRoot(inputFile) {
+				const fileOptions = inputFile.getFileOptions();
+				if (fileOptions.hasOwnProperty('isImport')) {
+					return !fileOptions.isImport;
+				}
+				return !hasUnderscore(inputFile.getPathInPackage());
+			}
+
+			function compileStylusFile(file) {
+				const contents = file.contents = file.getContentsAsString();
+				file.contents = `${pluginOptions.globalVariablesText}\n\n${contents || ''}`;
+
+				file.getContentsAsString = function getContentsAsStringWithGlobalVariables() {
+					return file.contents;
+				};
+
+				const source = {
+					path: ImportPathHelpers.getImportPathInPackage(file),
+					contents: file.getContentsAsString(),
+					file
+				};
+
+				let result;
+				try {
+					result = processor.process(file, source, './', allFiles);
+				} catch (err) {
+					file.error({
+						message: `CSS modules stylus compiler error: ${JSON.stringify(err, Object.getOwnPropertyNames(err))}\n`,
 						sourcePath: file.getDisplayPath()
 					});
 					return null;

--- a/options.js
+++ b/options.js
@@ -17,6 +17,7 @@ function getDefaultOptions() {
 	return {
 		enableProfiling: false,
 		enableSassCompilation: ['scss', 'sass'],
+		enableStylusCompilation: ['m.styl'],
 		explicitIncludes: [],
 		extensions: ['m.css', 'mss'],
 		globalVariablesText: '',

--- a/package.js
+++ b/package.js
@@ -15,6 +15,7 @@ Package.registerBuildPlugin({
 		'caching-compiler@1.0.0',
 		'nathantreid:css-modules-import-path-helpers@0.0.2',
 		'ramda:ramda@0.19.0',
+		'underscore',
 	],
 	npmDependencies: {
 		"app-module-path": "1.0.4",
@@ -30,6 +31,7 @@ Package.registerBuildPlugin({
 		"postcss-modules-values": "1.1.1",
 		"recursive-readdir": "1.3.0",
 		"string-template": "1.0.0",
+		"stylus": "0.54.2",
 	},
 	sources: [
 		'sha1.js',
@@ -38,6 +40,7 @@ Package.registerBuildPlugin({
 		'options.js',
 		'postcss-plugins.js',
 		'scss-processor.js',
+		'stylus-processor.js',
 		'css-modules-processor.js',
 		'css-modules-build-plugin.js',
 		'plugin.js'

--- a/stylus-processor.js
+++ b/stylus-processor.js
@@ -1,0 +1,143 @@
+import Future from 'fibers/future';
+import stylus from 'stylus';
+import path from 'path';
+import fs from 'fs';
+import IncludedFile from './included-file';
+import pluginOptions from './options';
+
+export default class StylusProcessor {
+	constructor(root, allFiles) {
+		this.root = root;
+		this.fileCache = {};
+		this.allFiles = allFiles;
+	}
+
+	process(file, _source, _relativeTo) {
+		return processInternal.call(this, _source, _relativeTo);
+
+		function processInternal(sourceFilePath, relativeTo) {
+			relativeTo = relativeTo.replace(/.*(\{.*)/, '$1').replace(/\\/g, '/');
+			const sourceFile = getSourceContents(sourceFilePath, relativeTo);
+			if (!sourceFile)
+				return '';
+
+			const cachedResult = this.fileCache[sourceFile.path];
+			if (cachedResult)
+				return cachedResult;
+
+			const { sourceContent, sourceMap } = this.load(sourceFile);
+			return this.fileCache[sourceFile.path] = {contents: sourceContent, source: sourceContent, sourceMap: sourceMap};
+		}
+
+		function getSourceContents(source, relativeTo) {
+			if (source instanceof String || typeof source === "string") {
+				source = ImportPathHelpers.getImportPathRelativeToFile(source, relativeTo);
+				return importModule(source);
+			}
+			return source;
+		}
+
+		function importModule(importPath) {
+			try {
+				if (!path.extname(importPath))
+					importPath += '.styl';
+
+				let file = allFiles.get(importPath);
+				if (!file && path.basename(file).indexOf('_' === -1))
+					file = allFiles.get(`${path.dirname(importPath)}/_${path.basename(importPath)}`);
+
+				return {path: importPath, contents: file.getContentsAsString(), file: file};
+			} catch (err) {
+				console.error(err);
+				file.error({
+					message: `CSS modules Stylus compiler error: file not found: (${importPath}): ${JSON.stringify(err, Object.getOwnPropertyNames(err))}\n`,
+					sourcePath: file.getDisplayPath()
+				});
+				return;
+			}
+		}
+	}
+
+	load(sourceFile) {
+		const allFiles = this.allFiles;
+		const future = new Future();
+		const resolver = future.resolver();
+		const options = {
+			filename: sourceFile.path,
+			sourcemap: {
+				comment: false
+			}
+		};
+
+		stylus.render(sourceFile.contents, options, function(err, css) {
+			if (err) {
+				return resolver(err);
+			}
+
+			resolver(null, {sourceContent: css, sourceMap: stylus.sourcemap});
+		});
+
+		return future.wait();
+
+		function importer(sourceFilePath, relativeTo) {
+			const sourceFile = getSourceContents(this.fileCache, sourceFilePath, relativeTo);
+			if (!sourceFile)
+				return '';
+
+			return sourceFile;
+		}
+
+		function getSourceContents(fileCache, source, relativeTo) {
+			if (source instanceof String || typeof source === "string") {
+				const sourcePath = ImportPathHelpers.getImportPathRelativeToFile(source, relativeTo);
+				const cachedResult = fileCache[sourcePath];
+				if (cachedResult)
+					return cachedResult;
+
+				return importModule(sourcePath);
+			}
+			return source;
+		}
+
+		function importModule(importPath) {
+			try {
+				const originalImportPath = importPath;
+				if (!path.extname(importPath))
+					importPath += '.scss';
+
+				let file = allFiles.get(importPath);
+				if (!file && path.basename(file).indexOf('_' === -1))
+					file = allFiles.get(`${path.dirname(importPath)}/_${path.basename(importPath)}`);
+				if (!file) {
+					file = new IncludedFile(discoverImportPath(originalImportPath), sourceFile);
+					allFiles.set(originalImportPath, file);
+				}
+
+				return {contents: file.getContentsAsString(), file: importPath};
+
+				function discoverImportPath(importPath) {
+					const potentialPaths = [importPath];
+					const potentialFileExtensions = pluginOptions.enableSassCompilation === true ? pluginOptions.extensions : pluginOptions.enableSassCompilation;
+
+					if (!path.extname(importPath))
+						potentialFileExtensions.forEach(extension=>potentialPaths.push(`${importPath}.${extension}`));
+					if (path.basename(importPath)[0] !== '_')
+						[].concat(potentialPaths).forEach(potentialPath=>potentialPaths.push(`${path.dirname(potentialPath)}/_${path.basename(potentialPath)}`));
+
+					for (let i = 0, potentialPath = potentialPaths[i]; i < potentialPaths.length; i++, potentialPath = potentialPaths[i])
+						if (fs.existsSync(potentialPaths[i]))
+							return potentialPath;
+
+					throw new Error(`File '${importPath}' not found at any of the following paths: ${JSON.stringify(potentialPaths)}`);
+				}
+			} catch (err) {
+				console.error(err);
+				sourceFile.file.error({
+					message: `CSS modules SCSS compiler error: file not found: (${importPath}): ${JSON.stringify(err, Object.getOwnPropertyNames(err))}\n`,
+					sourcePath: sourceFile.file.getDisplayPath()
+				});
+				return new Error(`CSS modules SCSS compiler error: file not found: (${importPath}): ${JSON.stringify(err, Object.getOwnPropertyNames(err))}\n`);
+			}
+		}
+	}
+};


### PR DESCRIPTION
PR for issue #19 

I've done some initial testing in my legacy project and it seems to work.  We could probably factor out the common code between this and the sass plugin.

I haven't tested sourcemap support, but have added what I think should make it work.

Note: I did the extension processing a little differently (see link below) than the sass plugin because I have a lot of existing '*.import.styl' files in my legacy project and only wanted css module to process 'm.styl' files.

https://github.com/pward123/meteor-css-modules/blob/621f2996ff3bcb8d951a8122b1e6260474eff0e6/css-modules-build-plugin.js#L175-L177
