### PR TITLE
Hotloading POC

### DIFF
--- a/addRemoveStyles.js
+++ b/addRemoveStyles.js
@@ -1,0 +1,25 @@
+var doc = document;
+var head = doc.getElementsByTagName("head").item(0);
+
+exports.addStyles = function (css) {
+  var style = doc.createElement("style");
+
+  style.setAttribute("type", "text/css");
+
+  // https://msdn.microsoft.com/en-us/library/ms535871(v=vs.85).aspx
+  var internetExplorerSheetObject =
+    style.sheet || // Edge/IE11.
+    style.styleSheet; // Older IEs.
+
+  if (internetExplorerSheetObject) {
+    internetExplorerSheetObject.cssText = css;
+  } else {
+    style.appendChild(doc.createTextNode(css));
+  }
+
+  return head.appendChild(style);
+};
+
+exports.removeStyleTag = function(element) {
+  head.removeChild(element);
+};

--- a/css-modules-build-plugin.js
+++ b/css-modules-build-plugin.js
@@ -226,7 +226,7 @@ export default class CssModulesBuildPlugin extends CachingCompiler {
 				file.addStylesheet({
 					data: result.source,
 					path: getOutputPath(filePath, pluginOptions.outputCssFilePath) + '.css',
-					sourceMap: JSON.stringify(result.sourceMap),
+//					sourceMap: JSON.stringify(result.sourceMap),
 					lazy: false
 				});
 			}
@@ -236,8 +236,12 @@ export default class CssModulesBuildPlugin extends CachingCompiler {
 			? result.imports.map(importPath=>`import '${importPath}';`).join('\n')
 			: '';
 		const stylesheetCode = (isLazy && shouldAddStylesheet && result.source)
-			? `import modules from 'meteor/modules';
-					 modules.addStyles(${JSON.stringify(result.source)});`
+			? `import { addStyles, removeStyleTag } from 'meteor/nathantreid:css-modules';
+				 const element = addStyles(${JSON.stringify(result.source)});
+				 if (module.hot) {
+				   module.hot.accept();
+				   module.hot.dispose(() => removeStyleTag(element));
+				 }`
 			: '';
 
 		const tokensCode = result.tokens

--- a/package.js
+++ b/package.js
@@ -16,6 +16,7 @@ Package.registerBuildPlugin({
 		'nathantreid:css-modules-import-path-helpers@0.1.2',
 		'ramda:ramda@0.19.0',
 		'underscore@1.0.7',
+		'gadicc:hot-build@0.0.8'
 	],
 	npmDependencies: {
 		"app-module-path": "1.0.4",
@@ -49,4 +50,7 @@ Package.registerBuildPlugin({
 Package.onUse(function (api) {
 	api.versionsFrom('1.3');
 	api.use('isobuild:compiler-plugin@1.0.0');
+	api.use('modules', 'client');
+	api.use('gadicc:hot@0.0.21', 'client');
+	api.mainModule('addRemoveStyles.js', 'client');
 });

--- a/plugin.js
+++ b/plugin.js
@@ -1,7 +1,9 @@
 import CssModulesBuildPlugin from './css-modules-build-plugin';
 import pluginOptionsWrapper from './options';
+import { Hot } from 'meteor/gadicc:hot-build';
 
 const pluginOptions = pluginOptionsWrapper.options;
+const hot = new Hot('nathantreid:css-modules/mss');
 
 ImportPathHelpers.init(Plugin);
 
@@ -9,5 +11,5 @@ Plugin.registerCompiler({
 	extensions: pluginOptions.extensions,
 	archMatching: pluginOptions.specificArchitecture
 }, function () {
-	return new CssModulesBuildPlugin(Plugin);
+	return hot.wrap(new CssModulesBuildPlugin(Plugin));
 });


### PR DESCRIPTION
This isn't to merge, just FYI.  It's for my most recently published package, which isn't well tested yet.  Nevertheless, the hotloading works great :)  If you check it out locally, I think you'll like it, but I only tested the css-modules-specific hotloading in a very simple scenario.

Some notes:
- I didn't test without `ecmascript-hot` too; it's possible I still export some needed stuff from there to the global scope, not sure.
- I have that sourcemap line we discussed in the other issue commented out, since that's the only way I could get it to work in latest Meteor.
- There seems to be a CPU spike _after_ the last `addJavaScript()` is called, it seems to go through all the react-toolbox files again and the Meteor files, but not do anything with them.  But I didn't look at it properly.
- Other question is how to distribute.  Probably I need to add something to `package.json` to enable hotloading which is disabled by default.  Alternatively, you could publish a css-modules-hot.  Will think more about this.
- It also occurred to me that we should probably remove the `hot.accept()` line, since other files will be importing this file, so the exported data has to flow up the tree (and not just replace the CSS).  Had only tested isolated SCSS until now.
