### PR TITLE
add filenames option

### DIFF
--- a/options.js
+++ b/options.js
@@ -16,6 +16,7 @@ function getDefaultOptions() {
 		explicitIncludes: [],
 		ignorePaths: [],
 		extensions: ['m.css', 'mss'],
+		filenames: [],
 		globalVariablesText: '',
 		outputJsFilePath: '{dirname}/{basename}{extname}',
 		outputCssFilePath: '{dirname}/{basename}{extname}',

--- a/plugin.js
+++ b/plugin.js
@@ -7,7 +7,8 @@ ImportPathHelpers.init(Plugin);
 
 Plugin.registerCompiler({
 	extensions: pluginOptions.extensions,
-	archMatching: pluginOptions.specificArchitecture
+	archMatching: pluginOptions.specificArchitecture,
+	filenames: pluginOptions.filenames
 }, function () {
 	return new CssModulesBuildPlugin(Plugin);
 });


### PR DESCRIPTION
I want to use react-flexbox-grid on meteor.
https://github.com/roylee0704/react-flexbox-grid

This package had been changed to use css-module.

and I can't change the target css file extension to 'm.css' or 'mss'.
because the 'flexboxgrid.css' is included by another npm package such 
https://github.com/kristoferjoseph/flexboxgrid

so, I need to use your css-module compiler by specific filename (not only extension)

ex) package.json

```
  "cssModules": {
    "filenames": [ "flexboxgrid.css", "flexboxgrid.min.css"]
  },
```

regards.
