### PR TITLE
CSS Modules learned to handle a new option; namingConvention.trimNameParts

### DIFF
--- a/options.js
+++ b/options.js
@@ -26,7 +26,10 @@ function getDefaultOptions() {
 		outputJsFilePath: '{dirname}/{basename}{extname}',
 		outputCssFilePath: '{dirname}/{basename}{extname}',
 		passthroughPaths: [],
-		specificArchitecture: 'web'
+		specificArchitecture: 'web',
+		namingConvention:{
+			trimNameParts: []
+		}
 	};
 }
 

--- a/postcss-plugins.js
+++ b/postcss-plugins.js
@@ -15,8 +15,18 @@ corePlugins['postcss-modules-scope'].generateScopedName = function generateScope
 	let sanitisedPath = path.relative(ImportPathHelpers.basePath, filePath).replace(/.*\{}[/\\]/, '').replace(/.*\{.*?}/, 'packages').replace(/\.[^\.\/\\]+$/, '').replace(/[\W_]+/g, '_').replace(/^_|_$/g, '');
 	const filename = path.basename(filePath).replace(/\.[^\.\/\\]+$/, '').replace(/[\W_]+/g, '_').replace(/^_|_$/g, '');
 	sanitisedPath = sanitisedPath.replace(new RegExp(`_(${filename})$`), '__$1');
-	return `_${sanitisedPath}__${exportedName}`;
+	return trimNameParts(`_${sanitisedPath}__${exportedName}`);
 };
+
+function trimNameParts(name){
+	if (!pluginOptions.namingConvention || !pluginOptions.namingConvention.trimNameParts || pluginOptions.namingConvention.trimNameParts.length == 0) return name;
+
+	let trimmed = name;
+	for (let t of pluginOptions.namingConvention.trimNameParts){
+		trimmed = trimmed.replace(t, '');
+	}
+	return trimmed;
+}
 
 export default loadPlugins();
 


### PR DESCRIPTION
As per discussion #58, this PR makes it possible to configure trimming of component part names. 

I added the `trimNameParts` option in an object named `namingConvention` as I guess there might be more options added here in the future, like `hashMode` (noHash, addHash, hashOnly), `separatorCharacter`, ++.

I am in a limited setting in regards to testing this. I didn't want to create an Atmosphere package, just to test it, and I couldn't get the dev environment set up to test it locally (I am on Windows , which might be the cause of that problem... :()

But I added a test for the core changes here: https://jsbin.com/sowavecigi/3/edit?js,console
