### PR TITLE
Allow node-sass 5.x

### DIFF
--- a/options.js
+++ b/options.js
@@ -104,7 +104,7 @@ function checkSassCompilation(options) {
 
   if (options.enableSassCompilation === true ||
     (Array.isArray(options.enableSassCompilation) && R.intersection(options.enableSassCompilation, options.extensions).length)) {
-    const result = checkNpmPackage('node-sass@>=3.x <=4.x');
+    const result = checkNpmPackage('node-sass@>=3.x <=5.x');
     if (result === true) return;
   }
   options.enableSassCompilation = false;


### PR DESCRIPTION
The [breaking changes in 5.0.0](https://github.com/sass/node-sass/releases/tag/v5.0.0) are minimal and do not affect the code in meteor-css-modules